### PR TITLE
Changing to isLeapSecond

### DIFF
--- a/json/schema/smpte-tlx-items.json
+++ b/json/schema/smpte-tlx-items.json
@@ -42,7 +42,7 @@
       "description": "Creation time of this TLX label.",
       "examples": [
         { "ptpTime": [ 1234567890, 999999999 ], "currentLocalOffset": -25163,
-          "leapSecondEvent": false },
+          "isLeapSecond": false },
         { "ptpTime": [ 12345678901, 999999999 ], "currentLocalOffset": -25163},
         { "ptpTime": [ 12345678901, 999999999 ], "currentLocalOffset": -25163,
           "extensible": null }
@@ -69,9 +69,9 @@
           "type": "integer", "minimum": -2147483648, "exclusiveMaximum": 2147483648,
           "$comment": "ST 2059-2 limits to int32."
         },
-        "leapSecondEvent": {
-          "$id": "#TLXptpTimestamp/leapSecondEvent",
-          "title": "TLXptpTimestamp/leapSecondEvent",
+        "isLeapSecond": {
+          "$id": "#TLXptpTimestamp/isLeapSecond",
+          "title": "TLXptpTimestamp/isLeapSecond",
           "type": "boolean",
           "default": false
         }

--- a/json/schema/smpte-tlx-profiles.json
+++ b/json/schema/smpte-tlx-profiles.json
@@ -109,7 +109,7 @@
           "properties": {
             "ptpTime": {},
             "currentLocalOffset": {},
-            "leapSecondEvent": {}
+            "isLeapSecond": {}
           },
           "required": [ "ptpTime" ],
           "additionalProperties": false
@@ -202,7 +202,7 @@
           "properties": {
             "ptpTime": {},
             "currentLocalOffset": {},
-            "leapSecondEvent": {}
+            "isLeapSecond": {}
           },
           "additionalProperties": false
         },

--- a/json/tests/smpte-tlx-items/TLXptpTimestamp.json
+++ b/json/tests/smpte-tlx-items/TLXptpTimestamp.json
@@ -29,7 +29,7 @@
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890, 123456789 ],
                     "currentLocalOffset": -25163,
-                    "leapSecondEvent": true } },
+                    "isLeapSecond": true } },
             "valid": true
         },
         {

--- a/json/tests/smpte-tlx-profiles/TimeLoc.json
+++ b/json/tests/smpte-tlx-profiles/TimeLoc.json
@@ -30,7 +30,7 @@
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789],
                     "currentLocalOffset": -25163,
-                    "leapSecondEvent": false
+                    "isLeapSecond": false
                 }
             },
             "valid": true


### PR DESCRIPTION
Per decision on SEPT 2 TLX DG call, the leapSecondEvent attribute was name-changed to isLeapSecond to accompany an improved description.