### PR TITLE
localOffset

### DIFF
--- a/json/schema/smpte-tlx-items.json
+++ b/json/schema/smpte-tlx-items.json
@@ -8,7 +8,7 @@
   "examples": [
     {
       "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-        "currentLocalOffset": -25163 },
+        "localOffset": -25237 },
       "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
       "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
     },
@@ -41,10 +41,10 @@
       "type": "object",
       "description": "Creation time of this TLX label.",
       "examples": [
-        { "ptpTime": [ 1234567890, 999999999 ], "currentLocalOffset": -25163,
+        { "ptpTime": [ 1234567890, 999999999 ], "localOffset": -25237,
           "isLeapSecond": false },
-        { "ptpTime": [ 12345678901, 999999999 ], "currentLocalOffset": -25163},
-        { "ptpTime": [ 12345678901, 999999999 ], "currentLocalOffset": -25163,
+        { "ptpTime": [ 12345678901, 999999999 ], "localOffset": -25237},
+        { "ptpTime": [ 12345678901, 999999999 ], "localOffset": -25237,
           "extensible": null }
       ],
       "properties": {
@@ -63,9 +63,9 @@
           "minItems": 2,
           "additionalItems": false
         },
-        "currentLocalOffset": {
-          "$id": "#TLXptpTimestamp/currentLocalOffset",
-          "title": "TLXptpTimestamp/currentLocalOffset",
+        "localOffset": {
+          "$id": "#TLXptpTimestamp/localOffset",
+          "title": "TLXptpTimestamp/localOffset",
           "type": "integer", "minimum": -2147483648, "exclusiveMaximum": 2147483648,
           "$comment": "ST 2059-2 limits to int32."
         },

--- a/json/schema/smpte-tlx-profiles.json
+++ b/json/schema/smpte-tlx-profiles.json
@@ -15,7 +15,7 @@
       "examples": [
         {
           "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-            "currentLocalOffset": -25163 },
+            "localOffset": -25237 },
           "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
           "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
         }
@@ -101,14 +101,14 @@
       "examples": [
         {
           "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-            "currentLocalOffset": -25163 }
+            "localOffset": -25237 }
         }
       ],
       "properties": {
         "TLXptpTimestamp": {
           "properties": {
             "ptpTime": {},
-            "currentLocalOffset": {},
+            "localOffset": {},
             "isLeapSecond": {}
           },
           "required": [ "ptpTime" ],
@@ -128,16 +128,16 @@
       "examples": [
         {
           "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-            "currentLocalOffset": -25163 }
+            "localOffset": -25237 }
         }
       ],
       "properties": {
         "TLXptpTimestamp": {
           "properties": {
             "ptpTime": {},
-            "currentLocalOffset": {}
+            "localOffset": {}
           },
-          "required": [ "ptpTime", "currentLocalOffset" ]
+          "required": [ "ptpTime", "localOffset" ]
         }
       },
       "required": [ "TLXptpTimestamp" ]
@@ -173,7 +173,7 @@
       "examples": [
         {
           "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-            "currentLocalOffset": -25163 },
+            "localOffset": -25237 },
           "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
           "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
         },
@@ -201,7 +201,7 @@
         "TLXptpTimestamp": {
           "properties": {
             "ptpTime": {},
-            "currentLocalOffset": {},
+            "localOffset": {},
             "isLeapSecond": {}
           },
           "additionalProperties": false
@@ -260,7 +260,7 @@
       "examples": [
         {
           "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-            "currentLocalOffset": -25163 },
+            "localOffset": -25237 },
           "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
         }
       ],

--- a/json/tests/smpte-tlx-items/TLXptpTimestamp.json
+++ b/json/tests/smpte-tlx-items/TLXptpTimestamp.json
@@ -21,15 +21,15 @@
             "description": "timestamp with local",
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890, 123456789 ],
-                    "currentLocalOffset": -25163 } },
+                    "localOffset": -25237 } },
             "valid": true
         },
         {
             "description": "timestamp with local and leapsecond",
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890, 123456789 ],
-                    "currentLocalOffset": -25163,
-                    "isLeapSecond": true } },
+                    "localOffset": -25237,
+                    "isLeapSecond": false } },
             "valid": true
         },
         {
@@ -66,21 +66,21 @@
             "description": "timestamp with local wrong type",
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890, 123456789 ],
-                    "currentLocalOffset": "-25163" } },
+                    "localOffset": "-25237" } },
             "valid": false
         },
         {
             "description": "timestamp with timestamp too long",
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890, 123456789, 0 ],
-                    "currentLocalOffset": -25163 } },
+                    "localOffset": -25237 } },
             "valid": false
         },
         {
             "description": "timestamp with timestamp missing ns",
             "TLX": { "TLXptpTimestamp":
                 { "ptpTime": [ 1234567890 ],
-                    "currentLocalOffset": -25163 } },
+                    "localOffset": -25237 } },
             "valid": false
         }
         

--- a/json/tests/smpte-tlx-profiles/DBC and TimeLoc.json
+++ b/json/tests/smpte-tlx-profiles/DBC and TimeLoc.json
@@ -16,7 +16,7 @@
             "valid": false
         },
         {
-            "description": "DBC with no currentLocalOffset",
+            "description": "DBC with no localOffset",
             "TLX": {
                 "TLXmediaCount": { "count": 300, "rate": [ 50, 1 ] },
                 "TLXptpTimestamp": { "ptpTime": [1234567890, 123456789 ] },
@@ -25,30 +25,30 @@
             "valid": false
         },
         {
-            "description": "DBC including currentLocalOffset",
+            "description": "DBC including localOffset",
             "TLX": {
                 "TLXmediaCount": { "count": 300, "rate": [ 50, 1 ] },
                 "TLXptpTimestamp": { "ptpTime": [1234567890, 123456789 ],
-                    "currentLocalOffset": -25237 },
+                    "localOffset": -25237 },
                 "TLXuniqueSourceID": { "sourceID": "51793043-be99-4c40-9d9f-b1e865e516c5" }
             },
             "valid": true
         },
         {
-            "description": "partial DBC, but including currentLocalOffset",
+            "description": "partial DBC, but including localOffset",
             "TLX": {
                 "TLXptpTimestamp": { "ptpTime": [1234567890, 123456789 ],
-                    "currentLocalOffset": -25237 },
+                    "localOffset": -25237 },
                 "TLXuniqueSourceID": { "sourceID": "51793043-be99-4c40-9d9f-b1e865e516c5" }
             },
             "valid": false
         },
         {
-            "description": "partial DBC, but including currentLocalOffset",
+            "description": "partial DBC, but including localOffset",
             "TLX": {
                 "TLXmediaCount": { "count": 300, "rate": [ 50, 1 ] },
                 "TLXptpTimestamp": { "ptpTime": [1234567890, 123456789 ],
-                    "currentLocalOffset": -25237 }
+                    "localOffset": -25237 }
             },
             "valid": false
         }

--- a/json/tests/smpte-tlx-profiles/TLXv1.json
+++ b/json/tests/smpte-tlx-profiles/TLXv1.json
@@ -18,7 +18,19 @@
             "description": "DBC ",
             "TLX": {
                 "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-                  "currentLocalOffset": -25163 },
+                  "localOffset": -25237 },
+                "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
+                "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
+            },
+            "valid": true
+        },
+        {
+            "description": "DBC with isLeapSecond",
+            "TLX": {
+                "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
+                  "localOffset": -25237,
+                  "isLeapSecond": false
+                },
                 "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
                 "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" }
             },
@@ -73,7 +85,7 @@
             "TLX": {
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789 ],
-                    "currentLocalOffset": -25163,
+                    "localOffset": -25237,
                     "extra": "shouldn't be here"
                 }
             },
@@ -115,7 +127,7 @@
             "description": "DBC + extra item",
             "TLX": {
                 "TLXptpTimestamp": { "ptpTime": [ 1234567890, 123456789 ],
-                  "currentLocalOffset": -25163 },
+                  "localOffset": -25237 },
                 "TLXmediaCount": { "count": 0, "rate": [ 30000, 1001 ] },
                 "TLXuniqueSourceID": { "sourceID": "3ac760e0-e11b-11eb-ba80-0242ac130004" },
                 "extra": { "object-worthy": "yes, but not here" }

--- a/json/tests/smpte-tlx-profiles/TimeLoc.json
+++ b/json/tests/smpte-tlx-profiles/TimeLoc.json
@@ -19,7 +19,7 @@
             "TLX": {
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789],
-                    "currentLocalOffset": -25163
+                    "localOffset": -25237
                 }
             },
             "valid": true
@@ -29,7 +29,7 @@
             "TLX": {
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789],
-                    "currentLocalOffset": -25163,
+                    "localOffset": -25237,
                     "isLeapSecond": false
                 }
             },
@@ -40,7 +40,7 @@
             "TLX": {
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789],
-                    "currentLocalOffset": -25163,
+                    "localOffset": -25237,
                     "extra": "always"
                 }
             },

--- a/json/tests/smpte-tlx-profiles/TimeOnly.json
+++ b/json/tests/smpte-tlx-profiles/TimeOnly.json
@@ -26,7 +26,18 @@
             "TLX": {
                 "TLXptpTimestamp": {
                     "ptpTime": [ 1234567890, 123456789 ],
-                    "currentLocalOffset": -25163
+                    "localOffset": -25237
+                }
+            },
+            "valid": true
+        },
+        {
+            "description": "timestamp only with offset",
+            "TLX": {
+                "TLXptpTimestamp": {
+                    "ptpTime": [ 1234567890, 123456789 ],
+                    "localOffset": -25237,
+                    "isLeapSecond": false
                 }
             },
             "valid": true


### PR DESCRIPTION
Per decisions from TLX DG on SEP 02,
  the attribute currentLocalOffset was renamed to localOffset.
A bug was found in that the TLX localOffset is not the ST 2059-2 current local offset during leap seconds.  The document has been  updated accordingly, but the name had to change to avoid confusion.

  Also, the incorrect value of -25163 was replaced with -25237 so as to have the correct sign when the count of leap seconds are applied.