### PR TITLE
all schema references update to match SMPTE-RA.org format

### DIFF
--- a/json/schema/smpte-tlx-items.json
+++ b/json/schema/smpte-tlx-items.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items",
+  "$id": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items",
   "title": "TLX",
   "type": "object",
   "description": "Schema for the SMPTE Extensible Time Label (TLX).",

--- a/json/schema/smpte-tlx-profiles.json
+++ b/json/schema/smpte-tlx-profiles.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles",
+  "$id": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles",
   "title": "TLX Profiles",
   "type": "object",
   "description": "Schemas for the SMPTE Extensible Time Label (TLX) Profiles, as specified in ST 2120-3, appear here as subschemas and should be referenced individually.",

--- a/json/tests/smpte-tlx-items/TLXmediaCount.json
+++ b/json/tests/smpte-tlx-items/TLXmediaCount.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXmediaCount",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-items/TLXmediaUnitInterval.json
+++ b/json/tests/smpte-tlx-items/TLXmediaUnitInterval.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXmediaUnitInterval",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
 
     },
     "tests": [

--- a/json/tests/smpte-tlx-items/TLXoverall.json
+++ b/json/tests/smpte-tlx-items/TLXoverall.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXoverall",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-items/TLXptpTimestamp.json
+++ b/json/tests/smpte-tlx-items/TLXptpTimestamp.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXptpTimestamp",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-items/TLXsourceName.json
+++ b/json/tests/smpte-tlx-items/TLXsourceName.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXsourceName",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-items/TLXst12.json
+++ b/json/tests/smpte-tlx-items/TLXst12.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXst12",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-items/TLXuniqueSourceID.json
+++ b/json/tests/smpte-tlx-items/TLXuniqueSourceID.json
@@ -3,7 +3,7 @@
     "schema": {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/TLXuniqueSourceID",
-        "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items"
+        "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items"
     },
     "tests": [
         {

--- a/json/tests/smpte-tlx-profiles/DBC and TimeLoc.json
+++ b/json/tests/smpte-tlx-profiles/DBC and TimeLoc.json
@@ -4,9 +4,9 @@
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/DBC-and-TimeLoc",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/DBC" },
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/TimeLoc" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/DBC" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/TimeLoc" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/DBC.json
+++ b/json/tests/smpte-tlx-profiles/DBC.json
@@ -4,8 +4,8 @@
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": "test/DBC",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/DBC" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/DBC" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/ST12-1.json
+++ b/json/tests/smpte-tlx-profiles/ST12-1.json
@@ -4,8 +4,8 @@
         "$id": "test/ST12-1",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/ST12-1" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/ST12-1" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/ST12-3.json
+++ b/json/tests/smpte-tlx-profiles/ST12-3.json
@@ -4,8 +4,8 @@
         "$id": "test/ST12-3",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/ST12-3" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/ST12-3" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/TLXv1.json
+++ b/json/tests/smpte-tlx-profiles/TLXv1.json
@@ -4,8 +4,8 @@
         "$id": "test/TLXv1",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/TLXv1" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/TLXv1" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/TimeLike.json
+++ b/json/tests/smpte-tlx-profiles/TimeLike.json
@@ -4,8 +4,8 @@
         "$id": "test/TimeLike",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/TimeLike" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/TimeLike" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/TimeLoc.json
+++ b/json/tests/smpte-tlx-profiles/TimeLoc.json
@@ -4,8 +4,8 @@
         "$id": "test/TimeLoc",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/TimeLoc" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/TimeLoc" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
      },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/TimeOnly.json
+++ b/json/tests/smpte-tlx-profiles/TimeOnly.json
@@ -4,8 +4,8 @@
         "$id": "test/TimeOnly",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/TimeOnly" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/TimeOnly" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/US-ASCII.json
+++ b/json/tests/smpte-tlx-profiles/US-ASCII.json
@@ -4,8 +4,8 @@
         "$id": "test/US-ASCII",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/US-ASCII" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/US-ASCII" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/countSEQ.json
+++ b/json/tests/smpte-tlx-profiles/countSEQ.json
@@ -4,8 +4,8 @@
         "$id": "test/countSEQ",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/countSEQ" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/countSEQ" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [

--- a/json/tests/smpte-tlx-profiles/ptpSEQ.json
+++ b/json/tests/smpte-tlx-profiles/ptpSEQ.json
@@ -4,8 +4,8 @@
         "$id": "test/ptpSEQ",
         "$schema": "http://json-schema.org/draft-07/schema",
         "allOf": [
-            { "$ref": "http://smpte-ra.org/2120/3/2021/smpte-tlx-profiles#$defs/ptpSEQ" },
-            { "$ref": "http://smpte-ra.org/2120/2/2021/smpte-tlx-items" }
+            { "$ref": "http://smpte-ra.org/schemas/2120-3/2021/smpte-tlx-profiles#$defs/ptpSEQ" },
+            { "$ref": "http://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items" }
         ]
     },
     "tests": [


### PR DESCRIPTION
The schema URI format for SMPTE-RA.org includes a /schemas directory in the path (which had been missing) and uses a hyphen to separate document part from the document number (not a slash).  FIXED.